### PR TITLE
Adds a "Schedule" tag with a value of "8:18"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-aws-cfpb",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "CFPB-specific Hubot aws commands. Forked from the excellent https://github.com/yoheimuta/hubot-aws/ and heavily modified for our particular usage needs",
   "repository": {
     "type": "git",

--- a/scripts/ec2/run.coffee
+++ b/scripts/ec2/run.coffee
@@ -151,6 +151,7 @@ module.exports = (robot) ->
       { Key: 'Software', Value: '' },
       { Key: 'BusinessOwner', Value: process.env.HUBOT_AWS_DEFAULT_CREATOR_EMAIL || "unknown" },
       { Key: 'SysAdmin', Value: user_email },
+      { Key: 'Schedule', Value: '8:18' },
       { Key: 'CreatedByApplication', Value: 'chat' },
       { Key: 'CreateDate', Value: "#{yyyy}-#{mm}-#{dd}"},
       { Key: 'ExpireDate', Value: "#{expyyyy}-#{expmm}-#{expdd}"}


### PR DESCRIPTION
This will cause any server created from chat to only run during normal business hours (Eastern
time).

Folks who need the server to be up on a different schedule can then
contact us subsequently, and we can make that change for them.

Addresses DEV-2153

:timer_clock: 