### PR TITLE
Improves 'Schedule' tag handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-aws-cfpb",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "CFPB-specific Hubot aws commands. Forked from the excellent https://github.com/yoheimuta/hubot-aws/ and heavily modified for our particular usage needs",
   "repository": {
     "type": "git",

--- a/scripts/ec2/extend_instance.coffee
+++ b/scripts/ec2/extend_instance.coffee
@@ -11,6 +11,7 @@
 
 ec2 = require('../../ec2.coffee')
 restrictor = require './restrictor'
+tags = require './tags'
 util = require 'util'
 
 getArgParams = (arg) ->
@@ -52,7 +53,10 @@ extendInstances = (msg, params, instances, err) ->
     ec2.createTags params, (err, res) ->
       return msg.send "Error! #{err}" if err
 
+      tags.addSchedule(msg, instances)
+
       msg.send "Successfully extended the expiration date to #{expireDatePretty}"
+      msg.send "\nThis instance defaults to running between 8 AM and 6 PM. You can change that schedule with the `ec2 schedule` command. See `bot help ec2 schedule` for details\n"
 
       # TODO break start_instances out into a decoupled function
       # Start instances after extending the expiration date

--- a/scripts/ec2/ls.coffee
+++ b/scripts/ec2/ls.coffee
@@ -177,7 +177,7 @@ messages_from_ec2_instances = (instances) ->
     schedule = ''
     for tag in instance.Tags when tag.Key is 'Schedule'
       schedule = tag.Value
-    backup = ''
+    backup = '[None]'
     for tag in instance.Tags when tag.Key is 'Backup'
       backup = tag.Value
 
@@ -191,7 +191,7 @@ messages_from_ec2_instances = (instances) ->
       description: description || ''
       expiration: expiration || ''
       schedule: schedule || ''
-      backup: backup || ''
+      backup: backup || '[None]'
     })
 
   messages.sort (a, b) ->

--- a/scripts/ec2/ls.coffee
+++ b/scripts/ec2/ls.coffee
@@ -202,7 +202,7 @@ messages_from_ec2_instances = (instances) ->
     resp = "\n| id | ip | name | state | description | type | launched | expires | schedule | backup |\n| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |\n"
 
     for m in messages
-      resp += "| #{m.id} | #{m.ip} | #{m.name} | #{m.state} | #{m.description} | #{m.type} | #{m.time} | #{m.expiration} | #{m.schedule} | #{backup} | \n"
+      resp += "| #{m.id} | #{m.ip} | #{m.name} | #{m.state} | #{m.description} | #{m.type} | #{m.time} | #{m.expiration} | #{m.schedule} | #{m.backup} | \n"
 
     resp += "---\n"
     return resp

--- a/scripts/ec2/restrictor.coffee
+++ b/scripts/ec2/restrictor.coffee
@@ -11,7 +11,7 @@ restrictor =
 
   addInstanceFilter: (msg, params, instances) ->
     params = restrictor.ensureFilters(params)
-    params['Filters'].push {Name: 'instance-id', Values: instances}
+    params['InstanceIds'] = instances
     return params
 
   addSubnetFilter: (msg, params) ->

--- a/scripts/ec2/run.coffee
+++ b/scripts/ec2/run.coffee
@@ -182,6 +182,7 @@ module.exports = (robot) ->
 
           messages.push("#{state}\t#{id}\t#{type}\t#{ip}\t#{name}")
           messages.push("\nIn about 10 minutes, you should be able to ssh in with ssh ec2-user@#{ip}\n")
+          messages.push("\nThis instance defaults to running between 8 AM and 6 PM. You can change that schedule with the `ec2 schedule` command. See `bot help ec2 schedule` for details\n")
 
         messages.sort()
         message = messages.join "\n"

--- a/scripts/ec2/schedule.coffee
+++ b/scripts/ec2/schedule.coffee
@@ -1,0 +1,73 @@
+# Description:
+#   Provides conveniences around certain tags we want to manage
+#
+# Commands:
+#   hubot ec2 schedule <instance_id> [<instance_id> ...] --start=start_hour --stop=stop_hour Adds an appropriate Schedule tag to the instance(s). Start and stop default to 8 AM to 6 PM
+#   hubot ec2 unschedule <instance_id> [<instance_id> ...] Removes the Schedule tag from the instance(s)
+#
+# Notes:
+#   instance_id : [required] The ID of one or more instances to modify tags. For example, i-0acec691.
+#   --start : On a 24 hour clock, what hour of the day to tag the instance to be started.
+#   --stop : On a 24 hour clock, what hour of the day to tag the instance to be stopped.
+#   --start and --stop **only results in a tag being added to the instance**. Other automations are responsible for implementing stop and start
+
+cson = require 'cson'
+restrictor = require './restrictor'
+tags = require './tags'
+util = require 'util'
+ec2 = require('../../ec2.coffee')
+
+# 8 am to 6 pm
+DEFAULT_SCHEDULE_START = 8
+DEFAULT_SCHEDULE_STOP = 18
+
+createInstancesArray = (instance_ids) ->
+    instances = []
+    instance_ids = instance_ids.replace /^\s+|\s+$/g, ""
+    for i in instance_ids.split /\s+/
+      if i and not i.match(/^--/)
+        instances.push(i)
+
+    return instances
+
+scheduleIfAuthorized = (msg, instances, schedule, err) ->
+  return (err) ->
+    return msg.send "Error! #{err}" if err
+    tags.addSchedule(msg, instances, schedule)
+
+unscheduleIfAuthorized = (msg, instances, err) ->
+  return (err) ->
+    return msg.send "Error! #{err}" if err
+    tags.removeSchedule(msg, instances)
+
+#credit: https://github.com/yoheimuta/hubot-aws/blob/master/scripts/ec2/create_tags.coffee
+getScheduleOptions = (args) ->
+
+  start_capture = /--start=(\d*?)( |$)/.exec(args)
+  start = if start_capture && (start_capture[1] >= 0 && start_capture[1] <= 24) then start_capture[1] else DEFAULT_SCHEDULE_START
+  stop_capture = /--stop=(\d*?)( |$)/.exec(args)
+  stop = if stop_capture && (stop_capture[1] >= 0 && stop_capture[1] <= 24) then stop_capture[1] else DEFAULT_SCHEDULE_STOP
+
+  return {start: start, stop: stop}
+
+module.exports = (robot) ->
+  robot.respond /ec2 schedule(.*)$/i, (msg) ->
+
+    instances = createInstancesArray(msg.match[1])
+    return msg.send "One or more instance_ids are required" if instances.length < 1
+
+    options = getScheduleOptions(msg.match[1])
+    schedule = "#{options.start}:#{options.stop}"
+
+    arg_params = restrictor.addUserCreatedFilter(msg, {})
+    restrictor.authorizeOperation(msg, arg_params, instances, scheduleIfAuthorized(msg, instances, schedule))
+    msg.send "Schedule added to #{instances}. Those instances will now start and stop on a schedule of #{schedule}"
+
+  robot.respond /ec2 unschedule(.*)$/i, (msg) ->
+
+      instances = createInstancesArray(msg.match[1])
+      return msg.send "One or more instance_ids are required" if instances.length < 1
+
+      arg_params = restrictor.addUserCreatedFilter(msg, {})
+      restrictor.authorizeOperation(msg, arg_params, instances, unscheduleIfAuthorized(msg, instances))
+      msg.send "Schedule removed from #{instances}"

--- a/scripts/ec2/schedule.coffee
+++ b/scripts/ec2/schedule.coffee
@@ -25,7 +25,7 @@ createInstancesArray = (instance_ids) ->
     instances = []
     instance_ids = instance_ids.replace /^\s+|\s+$/g, ""
     for i in instance_ids.split /\s+/
-      if i and not i.match(/^--/)
+      if i and i.match(/^i-/)
         instances.push(i)
 
     return instances

--- a/scripts/ec2/schedule.coffee
+++ b/scripts/ec2/schedule.coffee
@@ -34,11 +34,14 @@ scheduleIfAuthorized = (msg, instances, schedule, err) ->
   return (err) ->
     return msg.send "Error! #{err}" if err
     tags.addSchedule(msg, instances, schedule)
+    msg.send "Schedule added to #{instances}. Those instances will now start and stop on a schedule of #{schedule}"
+
 
 unscheduleIfAuthorized = (msg, instances, err) ->
   return (err) ->
     return msg.send "Error! #{err}" if err
     tags.removeSchedule(msg, instances)
+    msg.send "Schedule removed from #{instances}"
 
 #credit: https://github.com/yoheimuta/hubot-aws/blob/master/scripts/ec2/create_tags.coffee
 getScheduleOptions = (args) ->
@@ -61,7 +64,6 @@ module.exports = (robot) ->
 
     arg_params = restrictor.addUserCreatedFilter(msg, {})
     restrictor.authorizeOperation(msg, arg_params, instances, scheduleIfAuthorized(msg, instances, schedule))
-    msg.send "Schedule added to #{instances}. Those instances will now start and stop on a schedule of #{schedule}"
 
   robot.respond /ec2 unschedule(.*)$/i, (msg) ->
 
@@ -70,4 +72,3 @@ module.exports = (robot) ->
 
       arg_params = restrictor.addUserCreatedFilter(msg, {})
       restrictor.authorizeOperation(msg, arg_params, instances, unscheduleIfAuthorized(msg, instances))
-      msg.send "Schedule removed from #{instances}"

--- a/scripts/ec2/start_instance.coffee
+++ b/scripts/ec2/start_instance.coffee
@@ -10,6 +10,7 @@
 
 ec2 = require('../../ec2.coffee')
 restrictor = require './restrictor'
+tags = require './tags'
 util = require 'util'
 
 getArgParams = (arg) ->
@@ -33,6 +34,7 @@ startInstances = (msg, params, instances, err) ->
       return msg.send "Error! #{err}" if err
 
       msg.send "Success! The instances are starting"
+      tags.addSchedule(msg, instances)
       msg.send util.inspect(res, false, null)
 
 

--- a/scripts/ec2/stop.coffee
+++ b/scripts/ec2/stop.coffee
@@ -10,6 +10,7 @@
 
 ec2 = require('../../ec2.coffee')
 restrictor = require './restrictor'
+tags = require './tags'
 util = require 'util'
 
 getArgParams = (arg) ->
@@ -33,6 +34,8 @@ stopInstances = (msg, params, instances, err) ->
 
       msg.send "Success! The instances are stopping"
       msg.send util.inspect(res, false, null)
+
+      tags.removeSchedule(msg, instances)
 
 
 

--- a/scripts/ec2/tags.coffee
+++ b/scripts/ec2/tags.coffee
@@ -1,0 +1,17 @@
+
+cson = require 'cson'
+ec2 = require('../../ec2.coffee')
+util = require 'util'
+
+# Expose to other scripts
+tags =
+
+  addSchedule: (msg, instances, schedule="8:18") ->
+    ec2.createTags {Resources: instances, Tags: [Key: "Schedule", Value: schedule]}, (err, res) ->
+      return msg.send "Error creating tags: #{err}" if err
+
+  removeSchedule: (msg, instances) ->
+    return tags.addSchedule(msg, instances, "")
+
+module.exports = tags
+


### PR DESCRIPTION
1. Adds the ability to modify the 'Schedule' tag via new `schedule` and `unschedule commands`.

2. Removes a schedule when an instance is stopped, so that our scheduler doesn't start it.

3. Adds the default 8 AM to 6 PM schedule when an instance is started or extended