### PR TITLE
Bugfix: we should have used a metachar instead of an actual space

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-aws-cfpb",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "CFPB-specific Hubot aws commands. Forked from the excellent https://github.com/yoheimuta/hubot-aws/ and heavily modified for our particular usage needs",
   "repository": {
     "type": "git",

--- a/scripts/ec2/deploy_tags.coffee
+++ b/scripts/ec2/deploy_tags.coffee
@@ -25,9 +25,9 @@ reserveForDeploy = (msg, instance, reservation) ->
   msg.send "Reservation added to #{instance}."
 
 getReservationTags = (args) ->
-  reservationUser = ///--#{RESERVE_TAGS.user}=(.*?)( |$)///.exec(args)[1]
+  reservationUser = ///--#{RESERVE_TAGS.user}=(.*?)(\s+|$)///.exec(args)[1]
   reservationTime = Date.now().toString()
-  reservationBranch = ///--#{RESERVE_TAGS.branch}=(.*?)( |$)///.exec(args)[1]
+  reservationBranch = ///--#{RESERVE_TAGS.branch}=(.*?)(\s+|$)///.exec(args)[1]
   reservationDescription = ///--#{RESERVE_TAGS.description}="(.*?)"///.exec(args)[1]
   [
     {Key: RESERVE_TAGS.user, Value: reservationUser},


### PR DESCRIPTION
The CoffeeScript compiler was for some reason dropping the space when generating JS. But the `\s` would have been better in the first place.