### PR TITLE
Fix `ec2 run` so the instance name is displayed correctly

### DIFF
--- a/scripts/ec2/run.coffee
+++ b/scripts/ec2/run.coffee
@@ -177,10 +177,8 @@ module.exports = (robot) ->
           type  = ins.InstanceType
           for network in ins.NetworkInterfaces
             ip  = network.PrivateIpAddress
-          for tag in ins.Tags when tag.Key is 'Name'
-            name = tag.Value || '[NoName]'
 
-          messages.push("#{state}\t#{id}\t#{type}\t#{ip}\t#{name}")
+          messages.push("#{state}\t#{id}\t#{type}\t#{ip}\t#{aws_instance_name}")
           messages.push("\nIn about 10 minutes, you should be able to ssh in with ssh ec2-user@#{ip}\n")
           messages.push("\nThis instance defaults to running between 8 AM and 6 PM. You can change that schedule with the `ec2 schedule` command. See `bot help ec2 schedule` for details\n")
 


### PR DESCRIPTION
When creating a new ec2 instance via the bot, I saw this output:

```
pending    i-XXXXXXXXXX    m3.medium    10.XXX.XXX.XXX    undefined
```

There you can see `undefined` where the instance name should be displayed. My guess is that this is because the tags have not yet been added. But we already know the name, so we can display it without consulting the tags.