### PR TITLE
Improve ec2 ls

### DIFF
--- a/scripts/ec2/ls.coffee
+++ b/scripts/ec2/ls.coffee
@@ -217,7 +217,8 @@ handle_sending_message = (msg, messages) ->
   if messages.length < 1000
     msg.send messages
   else
-    gist {content: messages, enterpriseOnly: true}, (err, resp, data) ->
+    gistOpts = {content: messages, enterpriseOnly: true, fileExtension: 'md'}
+    gist gistOpts, (err, resp, data) ->
       url = data.html_url
       msg.send "View instances at: " + url
 

--- a/scripts/ec2/ls.coffee
+++ b/scripts/ec2/ls.coffee
@@ -180,6 +180,9 @@ messages_from_ec2_instances = (instances) ->
     backup = '[None]'
     for tag in instance.Tags when tag.Key is 'Backup'
       backup = tag.Value
+    creator = '[None]'
+    for tag in instance.Tags when tag.Key is 'Creator'
+      creator = tag.Value
 
     messages.push({
       time: moment(instance.LaunchTime).format('YYYY-MM-DD')
@@ -192,6 +195,7 @@ messages_from_ec2_instances = (instances) ->
       expiration: expiration || ''
       schedule: schedule || ''
       backup: backup || '[None]'
+      creator: creator
     })
 
   messages.sort (a, b) ->
@@ -199,10 +203,10 @@ messages_from_ec2_instances = (instances) ->
 
   resp = ""
   if messages.length
-    resp = "\n| id | ip | name | state | description | type | launched | expires | schedule | backup |\n| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |\n"
+    resp = "\n| id | ip | name | creator | state | description | type | launched | expires | schedule | backup |\n| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |\n"
 
     for m in messages
-      resp += "| #{m.id} | #{m.ip} | #{m.name} | #{m.state} | #{m.description} | #{m.type} | #{m.time} | #{m.expiration} | #{m.schedule} | #{m.backup} | \n"
+      resp += "| #{m.id} | #{m.ip} | #{m.name} | #{creator} | #{m.state} | #{m.description} | #{m.type} | #{m.time} | #{m.expiration} | #{m.schedule} | #{m.backup} | \n"
 
     resp += "---\n"
     return resp


### PR DESCRIPTION
This address https://github.com/cfpb/hubot-aws-cfpb/issues/27 to add a 'creator' column to the `ec2 ls` table.

It also attempts to fix the current problem where the gist is created with an `.sh` extension, causing GitHub not to render the table as markdown. I'm hoping that by adding the `.md` extension, the gist will render correctly now.
