### PR TITLE
DEV-2643 - update to use new `RunSchedule` tag and related format

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "moment": "2.20.1",
     "quick-gist": "^1.3.1",
     "tsv": "0.2.0",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "validator": "10.1.0"
   },
   "keywords": [
     "aws",

--- a/scripts/ec2/ls.coffee
+++ b/scripts/ec2/ls.coffee
@@ -178,7 +178,7 @@ messages_from_ec2_instances = (instances) ->
       name: getTag(instance.Tags, 'Name') || '[NoName]'
       description: getTag(instance.Tags, 'Description') || ''
       expiration: getTag(instance.Tags, 'ExpireDate') || ''
-      schedule: getTag(instance.Tags, 'Schedule') || ''
+      schedule: getTag(instance.Tags, tags.SCHEDULE_TAG) || ''
       backup: getTag(instance.Tags, 'Backup') || '[None]'
       creator: getTag(instance.Tags, 'Creator') || '[None]'
     })

--- a/scripts/ec2/run.coffee
+++ b/scripts/ec2/run.coffee
@@ -21,6 +21,8 @@ fs   = require 'fs'
 cson = require 'cson'
 util = require 'util'
 
+tags = require './tags'
+
 
 getArgParams = (arg) ->
   dry_run = if arg.match(/--dry-run/) then true else false
@@ -151,7 +153,7 @@ module.exports = (robot) ->
       { Key: 'Software', Value: '' },
       { Key: 'BusinessOwner', Value: process.env.HUBOT_AWS_DEFAULT_CREATOR_EMAIL || "unknown" },
       { Key: 'SysAdmin', Value: user_email },
-      { Key: 'Schedule', Value: '8:18' },
+      { Key: tags.SCHEDULE_TAG, Value: tags.formatSchedule(tags.DEFAULT_SCHEDULE) },
       { Key: 'CreatedByApplication', Value: 'chat' },
       { Key: 'CreateDate', Value: "#{yyyy}-#{mm}-#{dd}"},
       { Key: 'ExpireDate', Value: "#{expyyyy}-#{expmm}-#{expdd}"}

--- a/scripts/ec2/schedule.coffee
+++ b/scripts/ec2/schedule.coffee
@@ -22,13 +22,13 @@ DEFAULT_SCHEDULE_START = 8
 DEFAULT_SCHEDULE_STOP = 18
 
 createInstancesArray = (instance_ids) ->
-    instances = []
-    instance_ids = instance_ids.replace /^\s+|\s+$/g, ""
-    for i in instance_ids.split /\s+/
-      if i and i.match(/^i-/)
-        instances.push(i)
+  instances = []
+  instance_ids = instance_ids.replace /^\s+|\s+$/g, ""
+  for i in instance_ids.split /\s+/
+    if i and i.match(/^i-/)
+      instances.push(i)
 
-    return instances
+  return instances
 
 scheduleIfAuthorized = (msg, instances, schedule, err) ->
   return (err) ->
@@ -66,9 +66,8 @@ module.exports = (robot) ->
     restrictor.authorizeOperation(msg, arg_params, instances, scheduleIfAuthorized(msg, instances, schedule))
 
   robot.respond /ec2 unschedule(.*)$/i, (msg) ->
+    instances = createInstancesArray(msg.match[1])
+    return msg.send "One or more instance_ids are required" if instances.length < 1
 
-      instances = createInstancesArray(msg.match[1])
-      return msg.send "One or more instance_ids are required" if instances.length < 1
-
-      arg_params = restrictor.addUserCreatedFilter(msg, {})
-      restrictor.authorizeOperation(msg, arg_params, instances, unscheduleIfAuthorized(msg, instances))
+    arg_params = restrictor.addUserCreatedFilter(msg, {})
+    restrictor.authorizeOperation(msg, arg_params, instances, unscheduleIfAuthorized(msg, instances))

--- a/scripts/ec2/tags.coffee
+++ b/scripts/ec2/tags.coffee
@@ -1,10 +1,43 @@
 ec2 = require('../../ec2.coffee')
+moment = require('moment')
+validator = require('validator')
 
 
 tags =
-  addSchedule: (msg, instances, schedule = "8:18") ->
+
+  DEFAULT_SCHEDULE: "8:18"
+
+  SCHEDULE_TAG: "RunSchedule"
+
+  # convert our concise schedule strings ("8:18") to the new UTC-based format
+  formatSchedule: (hours) ->
+    [_, start, stop] = hours.match /^(\d{1,2}):(\d{1,2})$/
+
+    invalidHours = [start, stop]
+      .map((e) -> validator.isInt(e, {min: 0, max: 24}))
+      .some((e) -> !e)
+    if invalidHours
+      throw new Error("Start/stop hours must be between 0 and 24")
+
+    startUtc = moment({hour: start, minute: 0}).utc().hour().toString()
+    stopUtc = moment({hour: stop, minute: 0}).utc().hour().toString()
+    [
+      "#{startUtc.padStart(2, '0').padEnd(4, '0')}",
+      "#{stopUtc.padStart(2, '0').padEnd(4, '0')}",
+      "utc",
+      "mon,tue,wed,thu,fri",
+    ].join ";"
+
+  addSchedule: (msg, instances, schedule = tags.DEFAULT_SCHEDULE) ->
+    try
+      scheduleFmt = tags.formatSchedule schedule
+    catch e
+      return msg.send(
+        "Error parsing schedule; verify correct 24-hour format (eg '8:18')."
+      )
+
     ec2.createTags(
-      {Resources: instances, Tags: [Key: "Schedule", Value: schedule]},
+      {Resources: instances, Tags: [Key: SCHEDULE_TAG, Value: scheduleFmt]},
       (err, res) ->
         if err
           console.log "Error creating tags: #{err}"

--- a/scripts/ec2/tags.coffee
+++ b/scripts/ec2/tags.coffee
@@ -1,26 +1,24 @@
-
-cson = require 'cson'
 ec2 = require('../../ec2.coffee')
-util = require 'util'
 
-# Expose to other scripts
+
 tags =
-
-  addSchedule: (msg, instances, schedule="8:18") ->
-    ec2.createTags {Resources: instances, Tags: [Key: "Schedule", Value: schedule]}, (err, res) ->
-      if err
-        console.log "Error creating tags: #{err}"
-        if msg
-          return msg.send "Error creating tags: #{err}" if err
+  addSchedule: (msg, instances, schedule = "8:18") ->
+    ec2.createTags(
+      {Resources: instances, Tags: [Key: "Schedule", Value: schedule]},
+      (err, res) ->
+        if err
+          console.log "Error creating tags: #{err}"
+          if msg
+            return msg.send "Error creating tags: #{err}" if err
+    )
 
   removeSchedule: (msg, instances) ->
     return tags.addSchedule(msg, instances, "")
 
   addReservation:(msg, instance, content) ->
     ec2.createTags {Resources: [instance], Tags: content}, (err, res) ->
-        if msg
-          return msg.send "Error creating tags: #{err}" if err
-  
+      if msg
+        return msg.send "Error creating tags: #{err}" if err
+
 
 module.exports = tags
-


### PR DESCRIPTION
(Please review the third commit in isolation to avoid the noise introduced by the two lint/cleanup commits – thanks!)

We now use a UTC-based schedule tag format, and are also storing this new schedule information in a different ec2 tag (`RunSchedule` instead of `Schedule`).

It does appear that the new format accommodates day-based scheduling, however it's currently out of scope to add this functionality, and we will continue to assume Monday–Friday scheduling is what's wanted, since that's all the old instance scheduling setup supported. Future maintainers may want to expand the scheduling functionality to allow for more granularity – if, say, instances need to be up over the weekend.